### PR TITLE
FIX Prevent recursive dependency check while merging arrays

### DIFF
--- a/Controller/MessageController.php
+++ b/Controller/MessageController.php
@@ -607,7 +607,7 @@ class MessageController
 
             // merge the 2 groups array
             foreach ($userGroupsFinal as $userGroupFinal) {
-                if (!in_array($userGroupFinal, $groups)) {
+                if (!in_array($userGroupFinal, $groups, true)) {
                     $groups[] = $userGroupFinal;
                 }
             }


### PR DESCRIPTION
This is a fix for issue #15.

By default, in_array() applied to objects will test every property in the object. Setting the 3rd parameter to true enables strict mode, which does seem to _not_ trigger the 500 error.
